### PR TITLE
Card 관련 기능 구현

### DIFF
--- a/src/main/java/com/sparta/springtrello/annotation/RequestedMember.java
+++ b/src/main/java/com/sparta/springtrello/annotation/RequestedMember.java
@@ -1,0 +1,11 @@
+package com.sparta.springtrello.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestedMember {
+}

--- a/src/main/java/com/sparta/springtrello/common/BaseCode.java
+++ b/src/main/java/com/sparta/springtrello/common/BaseCode.java
@@ -1,5 +1,5 @@
 package com.sparta.springtrello.common;
 
 public interface BaseCode {
-    public ReasonDto getReasonHttpStatus();
+    ReasonDto getReasonHttpStatus();
 }

--- a/src/main/java/com/sparta/springtrello/common/ErrorStatus.java
+++ b/src/main/java/com/sparta/springtrello/common/ErrorStatus.java
@@ -48,7 +48,8 @@ public enum ErrorStatus implements BaseCode {
 
     //매니저 관련 예외
     NOT_FOUND_MANAGER(HttpStatus.NOT_FOUND,404,"해당 매니저를 찾을 수 없습니다."),
-
+    BAD_REQUEST_INVALID_CARD_OR_MEMBER(HttpStatus.BAD_REQUEST,400,"카드ID나 멤버ID가 유효하지 않습니다."),
+    BAD_REQUEST_ALREADY_MANAGER(HttpStatus.BAD_REQUEST,400,"해당 유저는 이미 해당 카드의 매니저입니다."),
 
     //멤버 관련 예외
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND,404,"해당 멤버를 찾을 수 없습니다."),

--- a/src/main/java/com/sparta/springtrello/common/ErrorStatus.java
+++ b/src/main/java/com/sparta/springtrello/common/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus implements BaseCode {
     FORBIDDEN_ACCESS_CHANGE_ROLE(HttpStatus.FORBIDDEN, 403, "해당 워크스페이스의 관리자가 아닙니다."),
     CONFLICT_MEMBER(HttpStatus.BAD_REQUEST, 400, "해당 유저는 이미 초대된 멤버입니다."),
     BAD_REQUEST_NOT_MEMBER(HttpStatus.BAD_REQUEST,404,"추가하려는 유저는 해당 워크스페이스의 멤버가 아닙니다."),
+    BAD_REQUEST_INVALID_WORKSPACE_ID(HttpStatus.BAD_REQUEST,400,"워크스페이스 ID가 잘못 입력되었습니다."),
 
     // 보드 관련 예외
     NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, 404, "해당 보드를 찾을 수 없습니다."),

--- a/src/main/java/com/sparta/springtrello/config/ArgumentResolverConfig.java
+++ b/src/main/java/com/sparta/springtrello/config/ArgumentResolverConfig.java
@@ -1,0 +1,20 @@
+package com.sparta.springtrello.config;
+
+import com.sparta.springtrello.domain.member.argumentresolver.MemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class ArgumentResolverConfig implements WebMvcConfigurer {
+    private final MemberArgumentResolver memberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(memberArgumentResolver);
+    }
+}

--- a/src/main/java/com/sparta/springtrello/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/springtrello/config/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.rmi.ServerException;
 
@@ -37,6 +38,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<String>> handleAuthException(AuthException ex) {
         HttpStatus status = HttpStatus.UNAUTHORIZED;
         return getErrorResponse(status, ex.getMessage());
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<String>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
+        HttpStatus status = HttpStatus.REQUEST_ENTITY_TOO_LARGE;
+        return getErrorResponse(status, "파일 크기는 5MB를 초과할 수 없습니다.");
     }
 
     public ResponseEntity<ApiResponse<String>> getErrorResponse(HttpStatus status, String message) {

--- a/src/main/java/com/sparta/springtrello/config/JwtUtil.java
+++ b/src/main/java/com/sparta/springtrello/config/JwtUtil.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/sparta/springtrello/config/JwtUtil.java
+++ b/src/main/java/com/sparta/springtrello/config/JwtUtil.java
@@ -40,7 +40,7 @@ public class JwtUtil {
 
         return BEARER_PREFIX +
                 Jwts.builder()
-                        .claim("id", id)
+                        .setSubject(String.valueOf(id))
                         .claim("email", email)
                         .claim("userRole", userRole)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))

--- a/src/main/java/com/sparta/springtrello/domain/auth/dto/AuthUser.java
+++ b/src/main/java/com/sparta/springtrello/domain/auth/dto/AuthUser.java
@@ -2,7 +2,6 @@ package com.sparta.springtrello.domain.auth.dto;
 
 import com.sparta.springtrello.domain.user.enums.UserRole;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 

--- a/src/main/java/com/sparta/springtrello/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/springtrello/domain/auth/service/AuthService.java
@@ -78,4 +78,8 @@ public class AuthService {
 
         return new SigninResponseDto(bearerToken);
     }
+
+    public static User fromAuthUser(AuthUser authUser) {
+        return new User(authUser.getId(), authUser.getEmail(), authUser.getUserRole());
+    }
 }

--- a/src/main/java/com/sparta/springtrello/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/springtrello/domain/auth/service/AuthService.java
@@ -11,8 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.regex.Pattern;
-
 @Service
 @RequiredArgsConstructor
 public class AuthService {

--- a/src/main/java/com/sparta/springtrello/domain/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/controller/BoardController.java
@@ -4,7 +4,6 @@ import com.sparta.springtrello.common.ApiResponse;
 import com.sparta.springtrello.domain.board.dto.BoardRequestDto;
 import com.sparta.springtrello.domain.board.dto.BoardResponseDto;
 import com.sparta.springtrello.domain.board.service.BoardService;
-import jakarta.validation.constraints.Null;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/sparta/springtrello/domain/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/controller/BoardController.java
@@ -18,7 +18,8 @@ public class BoardController {
 
     //보드 생성하기
     @PostMapping("/{workspacesId}/boards")
-    public ResponseEntity<ApiResponse<BoardResponseDto>> createBoard(@RequestBody BoardRequestDto boardRequestDto) {
+    public ResponseEntity<ApiResponse<BoardResponseDto>> createBoard(@RequestBody BoardRequestDto boardRequestDto,
+                                                                     @PathVariable Long workspacesId) {
        BoardResponseDto  createdBoard = boardService.createBoard(boardRequestDto);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(createdBoard));

--- a/src/main/java/com/sparta/springtrello/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/dto/BoardResponseDto.java
@@ -1,6 +1,5 @@
 package com.sparta.springtrello.domain.board.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
     @Getter

--- a/src/main/java/com/sparta/springtrello/domain/board/entity/Board.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/entity/Board.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 
 @Getter
 @Entity

--- a/src/main/java/com/sparta/springtrello/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/controller/CardController.java
@@ -67,5 +67,15 @@ public class CardController {
         return ResponseEntity.ok(ApiResponse.onSuccess(cardAttachmentService.attachFileToCard(member,cardId,file)));
     }
 
+    //카드 삭제
+    @DeleteMapping("/workspaces/{workspaceId}/boards/{boardId}/decks/{deckId}/{cardId}")
+    public ResponseEntity<ApiResponse<String>> delete(@PathVariable Long workspaceId,
+                                                      @PathVariable Long boardId,
+                                                      @PathVariable Long deckId,
+                                                      @PathVariable Long cardId,
+                                                      @RequestedMember Member member) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(cardService.delete(member,cardId)));
+    }
+
 }
 

--- a/src/main/java/com/sparta/springtrello/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/controller/CardController.java
@@ -4,14 +4,18 @@ import com.sparta.springtrello.annotation.RequestedMember;
 import com.sparta.springtrello.annotation.WorkspaceAccessButReadOnlyAuthorize;
 import com.sparta.springtrello.common.ApiResponse;
 import com.sparta.springtrello.domain.card.dto.request.CardCreateRequestDto;
+import com.sparta.springtrello.domain.card.dto.request.CardSearchRequestDto;
 import com.sparta.springtrello.domain.card.dto.request.CardUpdateRequestDto;
 import com.sparta.springtrello.domain.card.dto.response.CardAttachmentResponseDto;
 import com.sparta.springtrello.domain.card.dto.response.CardCreateResponseDto;
+import com.sparta.springtrello.domain.card.dto.response.CardSearchResponseDto;
 import com.sparta.springtrello.domain.card.dto.response.CardUpdateResponseDto;
 import com.sparta.springtrello.domain.card.service.CardAttachmentService;
 import com.sparta.springtrello.domain.card.service.CardService;
 import com.sparta.springtrello.domain.member.entity.Member;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -75,6 +79,15 @@ public class CardController {
                                                       @PathVariable Long cardId,
                                                       @RequestedMember Member member) {
         return ResponseEntity.ok(ApiResponse.onSuccess(cardService.delete(member,cardId)));
+    }
+
+    //카드 검색
+    @GetMapping("/workspaces/{workspaceId}/boards/{boardId}/decks/{deckId}/cards/search")
+    public ResponseEntity<ApiResponse<Page<CardSearchResponseDto>>> search(@PathVariable Long workspaceId,
+                                                                           @PathVariable Long boardId,
+                                                                           @PathVariable Long deckId,
+                                                                           @RequestBody @Valid CardSearchRequestDto requestDto) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(cardService.searchCards(requestDto)));
     }
 
 }

--- a/src/main/java/com/sparta/springtrello/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/controller/CardController.java
@@ -1,17 +1,71 @@
+package com.sparta.springtrello.domain.card.controller;
 
-//package com.sparta.springtrello.domain.card.controller;
-//
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@RestController
-//@RequiredArgsConstructor
-//public class CardController {
-//
-////    @PostMapping("/workspaces/{workspaceId}/lists/{listId}")
-////    public ResponseEntity<ApiResponse<CardCreateResponseDto>> create(@PathVariable Long workspaceId,
-////                                                                     @PathVariable Long listId) {
-////
-////    }
-//}
+import com.sparta.springtrello.annotation.RequestedMember;
+import com.sparta.springtrello.annotation.WorkspaceAccessButReadOnlyAuthorize;
+import com.sparta.springtrello.common.ApiResponse;
+import com.sparta.springtrello.domain.card.dto.request.CardCreateRequestDto;
+import com.sparta.springtrello.domain.card.dto.request.CardUpdateRequestDto;
+import com.sparta.springtrello.domain.card.dto.response.CardAttachmentResponseDto;
+import com.sparta.springtrello.domain.card.dto.response.CardCreateResponseDto;
+import com.sparta.springtrello.domain.card.dto.response.CardUpdateResponseDto;
+import com.sparta.springtrello.domain.card.service.CardAttachmentService;
+import com.sparta.springtrello.domain.card.service.CardService;
+import com.sparta.springtrello.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+public class CardController {
+    private final CardService cardService;
+    private final CardAttachmentService cardAttachmentService;
+
+    /**
+     * 카드 생성
+     * @param workspaceId : 현재 워크스페이스 Id
+     * @param boardId : 계층 구조를 유지하기 위한 url
+     * @param deckId : 카드를 추가하고자 하는 Deck Id
+     * @param member : 현재 인증된 Member 객체
+     * @param requestDto : title을 담고있는 requestDto
+     * @return : 카드Id, 카드title 를 담아서 반환하는 responseDto
+     */
+    @WorkspaceAccessButReadOnlyAuthorize
+    @PostMapping("/workspaces/{workspaceId}/boards/{boardId}/decks/{deckId}")
+    public ResponseEntity<ApiResponse<CardCreateResponseDto>> create(@PathVariable Long workspaceId,
+                                                                     @PathVariable Long boardId,
+                                                                     @PathVariable Long deckId,
+                                                                     @RequestedMember Member member,
+                                                                     @RequestBody CardCreateRequestDto requestDto) {
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(cardService.create(deckId,requestDto,member)));
+    }
+
+    //카드 수정
+    @WorkspaceAccessButReadOnlyAuthorize
+    @PutMapping("/workspaces/{workspaceId}/boards/{boardId}/decks/{deckId}/{cardId}")
+    public ResponseEntity<ApiResponse<CardUpdateResponseDto>> update(@PathVariable Long workspaceId,
+                                                                     @PathVariable Long boardId,
+                                                                     @PathVariable Long deckId,
+                                                                     @PathVariable Long cardId,
+                                                                     @RequestedMember Member member,
+                                                                     @RequestBody CardUpdateRequestDto requestDto) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(cardService.update(member,cardId,requestDto)));
+    }
+
+    //카드에 파일 첨부
+    @PostMapping("/workspaces/{workspaceId}/boards/{boardId}/decks/{deckId}/{cardId}")
+    public ResponseEntity<ApiResponse<CardAttachmentResponseDto>> attachFileToFile(@PathVariable Long workspaceId,
+                                                                      @PathVariable Long boardId,
+                                                                      @PathVariable Long deckId,
+                                                                      @PathVariable Long cardId,
+                                                                      @RequestedMember Member member,
+                                                                      @RequestParam("file") MultipartFile file) throws IOException {
+        return ResponseEntity.ok(ApiResponse.onSuccess(cardAttachmentService.attachFileToCard(member,cardId,file)));
+    }
+
+}
 

--- a/src/main/java/com/sparta/springtrello/domain/card/dto/request/CardSearchRequestDto.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/dto/request/CardSearchRequestDto.java
@@ -1,0 +1,26 @@
+package com.sparta.springtrello.domain.card.dto.request;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Date;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CardSearchRequestDto {
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
+    private int page = 1;
+    @Min(value = 1, message = "페이지 크기는 최소 1이어야 합니다.")
+    private int size = 10;
+    @Size(max = 255, message = "제목은 최대 255자까지 입력할 수 있습니다.")
+    private String title;
+    @Size(max = 20, message = "매니저 닉네임은 최대 20자까지 입력할 수 있습니다.")
+    private String managerNickname;
+    @FutureOrPresent(message = "마감일은 과거일 수 없습니다.")
+    private Date deadline;
+}

--- a/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardAttachmentResponseDto.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardAttachmentResponseDto.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 
 @Getter
 public class CardAttachmentResponseDto {
-    private Long cardId;
-    private String title;
-    private String fileUrl;
+    private final Long cardId;
+    private final String title;
+    private final String fileUrl;
 
     public CardAttachmentResponseDto(Long cardId,String title, String fileUrl) {
         this.cardId = cardId;

--- a/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardCreateResponseDto.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardCreateResponseDto.java
@@ -1,6 +1,5 @@
 package com.sparta.springtrello.domain.card.dto.response;
 
-import com.sparta.springtrello.domain.card.entity.Card;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardManagerChangedResponseDto.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardManagerChangedResponseDto.java
@@ -2,8 +2,6 @@ package com.sparta.springtrello.domain.card.dto.response;
 
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 public class CardManagerChangedResponseDto {
     private final Long cardId;

--- a/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardSearchResponseDto.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardSearchResponseDto.java
@@ -1,0 +1,12 @@
+package com.sparta.springtrello.domain.card.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CardSearchResponseDto {
+    private final Long cardId;
+    private final String cardTitle;
+    private final Long managerCount;
+}

--- a/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardUpdateResponseDto.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/dto/response/CardUpdateResponseDto.java
@@ -1,7 +1,6 @@
 package com.sparta.springtrello.domain.card.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.sparta.springtrello.domain.card.entity.Card;
 import lombok.Getter;
 
 import java.sql.Date;

--- a/src/main/java/com/sparta/springtrello/domain/card/entity/Card.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/entity/Card.java
@@ -33,9 +33,6 @@ public class Card  extends Timestamped {
     @JoinColumn(name = "deck_id")
     private Deck deck;
 
-    @OneToMany(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
-    private java.util.List<Manager> managerList = new ArrayList<>();
-
     public Card(String title) {
         this.title = title;
     }

--- a/src/main/java/com/sparta/springtrello/domain/card/entity/Card.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/entity/Card.java
@@ -3,14 +3,12 @@ package com.sparta.springtrello.domain.card.entity;
 import com.sparta.springtrello.common.Timestamped;
 import com.sparta.springtrello.domain.card.dto.request.CardUpdateRequestDto;
 import com.sparta.springtrello.domain.deck.entity.Deck;
-import com.sparta.springtrello.domain.manager.entity.Manager;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.sql.Date;
-import java.util.ArrayList;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/sparta/springtrello/domain/card/repository/CardQueryDslRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/repository/CardQueryDslRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CardQueryDslRepository {
-    public Page<CardSearchResponseDto> search(CardSearchRequestDto requestDto, Pageable pageable);
+    Page<CardSearchResponseDto> search(CardSearchRequestDto requestDto, Pageable pageable);
 }

--- a/src/main/java/com/sparta/springtrello/domain/card/repository/CardQueryDslRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/repository/CardQueryDslRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.springtrello.domain.card.repository;
+
+import com.sparta.springtrello.domain.card.dto.request.CardSearchRequestDto;
+import com.sparta.springtrello.domain.card.dto.response.CardSearchResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CardQueryDslRepository {
+    public Page<CardSearchResponseDto> search(CardSearchRequestDto requestDto, Pageable pageable);
+}

--- a/src/main/java/com/sparta/springtrello/domain/card/repository/CardQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/repository/CardQueryDslRepositoryImpl.java
@@ -1,0 +1,81 @@
+package com.sparta.springtrello.domain.card.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.springtrello.domain.card.dto.request.CardSearchRequestDto;
+import com.sparta.springtrello.domain.card.dto.response.CardSearchResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.util.List;
+
+import static com.sparta.springtrello.domain.card.entity.QCard.card;
+import static com.sparta.springtrello.domain.manager.entity.QManager.manager;
+
+@Repository
+@RequiredArgsConstructor
+public class CardQueryDslRepositoryImpl implements CardQueryDslRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<CardSearchResponseDto> search(CardSearchRequestDto requestDto, Pageable pageable) {
+        List<CardSearchResponseDto> results = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                CardSearchResponseDto.class,
+                                card.id,
+                                card.title,
+                                manager.countDistinct()
+                        )
+                )
+                .from(card)
+                .leftJoin(manager).fetchJoin().on(manager.card.id.eq(card.id), manager.isDeleted.eq(false))
+                .where(
+                        titleContains(requestDto.getTitle()),
+                        beforeDeadline(requestDto.getDeadline()),
+                        managerNicknameContains(requestDto.getManagerNickname()),
+                        cardNotDeleted()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .groupBy(card.id)
+                .orderBy(card.id.desc())
+                .fetch();
+
+        Long totalCount = jpaQueryFactory
+                .select(Wildcard.count)
+                .from(card)
+                .where(
+                        titleContains(requestDto.getTitle()),
+                        beforeDeadline(requestDto.getDeadline()),
+                        managerNicknameContains(requestDto.getManagerNickname()),
+                        cardNotDeleted()
+                )
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, totalCount);
+    }
+
+    private BooleanExpression titleContains(String title) {
+        return title != null ? card.title.containsIgnoreCase(title) : null;
+    }
+
+    private BooleanExpression beforeDeadline(Date deadline) {
+        return deadline != null ? card.deadline.loe(deadline) : null;
+    }
+
+    private BooleanExpression managerNicknameContains(String managerNickname) {
+        return managerNickname != null ? manager.member.user.nickname.containsIgnoreCase(managerNickname) : null;
+    }
+
+    private BooleanExpression cardNotDeleted() {
+        return card.isDeleted.eq(false);
+    }
+
+}

--- a/src/main/java/com/sparta/springtrello/domain/card/service/CardAttachmentService.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/service/CardAttachmentService.java
@@ -63,16 +63,23 @@ public class CardAttachmentService {
                 () -> new ApiException(ErrorStatus.INTERNAL_SERVER_ERROR_FAILED_CONVERT_FILE)
         );
 
-        //파일 경로를 String으로 반환
+        //파일 경로를 String 반환
         return convertFile.getAbsolutePath();
     }
 
     // 파일 convert 후 로컬에 업로드
     private Optional<File> convert(MultipartFile file) throws IOException {
         String uuidFilename = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String uploadDir = System.getProperty("user.dir") + "/upload/";
 
-        File convertFile = new File(System.getProperty("user.dir") + "/upload/" + uuidFilename);
-        if (convertFile.createNewFile()) { // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
+        // 해당 폴더가 존재하지 않으면 생성
+        File directory = new File(uploadDir);
+        if (!directory.exists()) {
+            directory.mkdirs(); // 경로에 디렉터리가 없으면 모든 상위 디렉터리도 포함해서 생성
+        }
+
+        File convertFile = new File(uploadDir + uuidFilename);
+        if (convertFile.createNewFile()) { // 지정한 경로에 파일이 생성됨 (경로가 잘못되었다면 생성 불가능)
             try (FileOutputStream fos = new FileOutputStream(convertFile)) {
                 fos.write(file.getBytes());
             }

--- a/src/main/java/com/sparta/springtrello/domain/card/service/CardService.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/service/CardService.java
@@ -62,4 +62,17 @@ public class CardService{
                 savedCard.getContents(),
                 savedCard.getDeadline());
     }
+
+    //카드 논리적 삭제
+    /*
+    1.현재 멤버가 카드의 매니저인지?
+     */
+    public String delete(Member requestedMember, Long cardId) {
+        Card card = cardFinder.findById(cardId);
+
+        managerUtil.validateCardManager(requestedMember,card);
+        card.delete();
+
+        return "삭제가 완료되었습니다.";
+    }
 }

--- a/src/main/java/com/sparta/springtrello/domain/card/service/CardService.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/service/CardService.java
@@ -1,10 +1,13 @@
 package com.sparta.springtrello.domain.card.service;
 
 import com.sparta.springtrello.domain.card.dto.request.CardCreateRequestDto;
+import com.sparta.springtrello.domain.card.dto.request.CardSearchRequestDto;
 import com.sparta.springtrello.domain.card.dto.request.CardUpdateRequestDto;
 import com.sparta.springtrello.domain.card.dto.response.CardCreateResponseDto;
+import com.sparta.springtrello.domain.card.dto.response.CardSearchResponseDto;
 import com.sparta.springtrello.domain.card.dto.response.CardUpdateResponseDto;
 import com.sparta.springtrello.domain.card.entity.Card;
+import com.sparta.springtrello.domain.card.repository.CardQueryDslRepository;
 import com.sparta.springtrello.domain.card.repository.CardRespository;
 import com.sparta.springtrello.domain.card.util.CardFinder;
 import com.sparta.springtrello.domain.deck.entity.Deck;
@@ -12,6 +15,9 @@ import com.sparta.springtrello.domain.deck.util.DeckFinder;
 import com.sparta.springtrello.domain.manager.util.ManagerUtil;
 import com.sparta.springtrello.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class CardService{
 
+    private final CardQueryDslRepository cardQueryDslRepository;
     private final CardRespository cardRespository;
     private final CardFinder cardFinder;
     private final DeckFinder deckFinder;
@@ -74,5 +81,12 @@ public class CardService{
         card.delete();
 
         return "삭제가 완료되었습니다.";
+    }
+
+    //카드 검색 페이지 처리 반환
+    public Page<CardSearchResponseDto> searchCards(CardSearchRequestDto requestDto) {
+        Pageable pageable = PageRequest.of(requestDto.getPage()-1, requestDto.getSize());
+
+        return cardQueryDslRepository.search(requestDto, pageable);
     }
 }

--- a/src/main/java/com/sparta/springtrello/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/springtrello/domain/comment/controller/CommentController.java
@@ -1,15 +1,11 @@
 package com.sparta.springtrello.domain.comment.controller;
 
 import com.sparta.springtrello.common.ApiResponse;
-import com.sparta.springtrello.common.ErrorStatus;
-import com.sparta.springtrello.common.exception.ApiException;
 import com.sparta.springtrello.domain.comment.dto.CommentRequestDto;
 import com.sparta.springtrello.domain.comment.dto.CommentResponseDto;
 import com.sparta.springtrello.domain.comment.entity.Comment;
-import com.sparta.springtrello.domain.comment.repository.CommentRepository;
 import com.sparta.springtrello.domain.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/sparta/springtrello/domain/comment/entity/Comment.java
+++ b/src/main/java/com/sparta/springtrello/domain/comment/entity/Comment.java
@@ -3,7 +3,6 @@ package com.sparta.springtrello.domain.comment.entity;
 import com.sparta.springtrello.common.Timestamped;
 import com.sparta.springtrello.domain.card.entity.Card;
 import com.sparta.springtrello.domain.member.entity.Member;
-import com.sparta.springtrello.domain.workspace.entity.Workspace;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/sparta/springtrello/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/springtrello/domain/comment/service/CommentService.java
@@ -4,13 +4,11 @@ import com.sparta.springtrello.common.ErrorStatus;
 import com.sparta.springtrello.common.exception.ApiException;
 import com.sparta.springtrello.domain.card.entity.Card;
 import com.sparta.springtrello.domain.card.repository.CardRespository;
-import com.sparta.springtrello.domain.comment.controller.CommentController;
 import com.sparta.springtrello.domain.comment.dto.CommentRequestDto;
 import com.sparta.springtrello.domain.comment.dto.CommentResponseDto;
 import com.sparta.springtrello.domain.comment.entity.Comment;
 import com.sparta.springtrello.domain.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/com/sparta/springtrello/domain/deck/controller/DeckController.java
+++ b/src/main/java/com/sparta/springtrello/domain/deck/controller/DeckController.java
@@ -9,7 +9,6 @@ import com.sparta.springtrello.domain.deck.service.DeckService;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/sparta/springtrello/domain/deck/controller/DeckController.java
+++ b/src/main/java/com/sparta/springtrello/domain/deck/controller/DeckController.java
@@ -27,7 +27,7 @@ public class DeckController {
      * @param deckName : 생성할 덱 이름
      * @return ApiResponse : message - "덱 생성 성공"/ Status Code - 200 / date - 생성된 덱 정보를 바인딩한 DeckResponse 객체
      */
-    @PostMapping("/workspaces/{workspaceId}/boards/{boadId}/decks")
+    @PostMapping("/workspaces/{workspaceId}/boards/{boardId}/decks")
     public ResponseEntity<ApiResponse<DeckCreateResponse>> createDeck(
             @PathVariable(name = "boardId") Long boardId,
             @RequestBody @NotBlank String deckName

--- a/src/main/java/com/sparta/springtrello/domain/deck/entity/Deck.java
+++ b/src/main/java/com/sparta/springtrello/domain/deck/entity/Deck.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/sparta/springtrello/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/controller/ManagerController.java
@@ -26,6 +26,7 @@ public class ManagerController {
                 requestedMember,cardId,toAddMemberId)));
     }
 
+    //담당자 삭제
     @DeleteMapping("/workspaces/{workspaceId}/boards/{boardId}/decks/{deckId}/{cardId}/manager")
     public ResponseEntity<ApiResponse<CardManagerChangedResponseDto>> deleteCardManager(@PathVariable Long workspaceId,
                                                                                         @PathVariable Long boardId,

--- a/src/main/java/com/sparta/springtrello/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/controller/ManagerController.java
@@ -1,0 +1,38 @@
+package com.sparta.springtrello.domain.manager.controller;
+
+import com.sparta.springtrello.annotation.RequestedMember;
+import com.sparta.springtrello.common.ApiResponse;
+import com.sparta.springtrello.domain.card.dto.response.CardManagerChangedResponseDto;
+import com.sparta.springtrello.domain.manager.service.ManagerService;
+import com.sparta.springtrello.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ManagerController {
+    private final ManagerService managerService;
+
+    //담당자 추가
+    @PostMapping("/workspaces/{workspaceId}/boards/{boardId}/decks/{deckId}/{cardId}/manager")
+    public ResponseEntity<ApiResponse<CardManagerChangedResponseDto>> addCardManager(@PathVariable Long workspaceId,
+                                                                                     @PathVariable Long boardId,
+                                                                                     @PathVariable Long deckId,
+                                                                                     @PathVariable Long cardId,
+                                                                                     @RequestedMember Member requestedMember,
+                                                                                     @RequestParam Long toAddMemberId) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(managerService.addCardManager(workspaceId,
+                requestedMember,cardId,toAddMemberId)));
+    }
+
+    @DeleteMapping("/workspaces/{workspaceId}/boards/{boardId}/decks/{deckId}/{cardId}/manager")
+    public ResponseEntity<ApiResponse<CardManagerChangedResponseDto>> deleteCardManager(@PathVariable Long workspaceId,
+                                                                                        @PathVariable Long boardId,
+                                                                                        @PathVariable Long deckId,
+                                                                                        @PathVariable Long cardId,
+                                                                                        @RequestedMember Member member,
+                                                                                        @RequestParam Long toRemoveMemberId) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(managerService.deleteCardManager(member,cardId,toRemoveMemberId)));
+    }
+}

--- a/src/main/java/com/sparta/springtrello/domain/manager/entity/Manager.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/entity/Manager.java
@@ -25,34 +25,12 @@ public class Manager {
 
     private boolean isDeleted = false;
 
-    /**
-     * 카드-매니저 연관관계 편의 메서드
-     * 이미 해당 카드에 이 객체가 메니저로 있다면 삭제하고 다시 추가
-     * @param card 매니저를 추가하고픈 카드
-     */
-    public void setCard(Card card) {
-        if(this.card != null && this.card.getManagerList().contains(this)) {
-            this.getCard().getManagerList().remove(this);
-        }
+    public Manager(Card card, Member member) {
         this.card = card;
-        card.getManagerList().add(this);
-    }
-
-    public void setMember(Member member) {
         this.member = member;
     }
 
-    /**
-     * 매니저 논리적 삭제
-     * 매니저를 삭제하고자하는 카드의 매니저 리스트에 해당 매니저가 있는지 확인하고
-     * 있다면 리스트에서 제거하고 논리적 삭제
-     * @param card : 매니저를 제거하고픈 카드
-     */
     public void delete(Card card) {
-        if (!card.getManagerList().contains(this)) {
-            throw new ApiException(ErrorStatus.BAD_REQUEST_NOT_MANAGER);
-        }
-        card.getManagerList().remove(this);
         this.isDeleted = true;
     }
 }

--- a/src/main/java/com/sparta/springtrello/domain/manager/entity/Manager.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/entity/Manager.java
@@ -1,7 +1,5 @@
 package com.sparta.springtrello.domain.manager.entity;
 
-import com.sparta.springtrello.common.ErrorStatus;
-import com.sparta.springtrello.common.exception.ApiException;
 import com.sparta.springtrello.domain.card.entity.Card;
 import com.sparta.springtrello.domain.member.entity.Member;
 import jakarta.persistence.*;
@@ -30,7 +28,7 @@ public class Manager {
         this.member = member;
     }
 
-    public void delete(Card card) {
+    public void delete() {
         this.isDeleted = true;
     }
 }

--- a/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerQueryDslRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerQueryDslRepository.java
@@ -1,5 +1,5 @@
 package com.sparta.springtrello.domain.manager.repository;
 
 public interface ManagerQueryDslRepository {
-    public boolean isMemberManager(Long cardId, Long memberId);
+    boolean isMemberManager(Long cardId, Long memberId);
 }

--- a/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerQueryDslRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerQueryDslRepository.java
@@ -1,0 +1,5 @@
+package com.sparta.springtrello.domain.manager.repository;
+
+public interface ManagerQueryDslRepository {
+    public boolean isMemberManager(Long cardId, Long memberId);
+}

--- a/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerQueryDslRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.sparta.springtrello.domain.manager.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.springtrello.common.ErrorStatus;
+import com.sparta.springtrello.common.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.sparta.springtrello.domain.manager.entity.QManager.manager;
+
+@Repository
+@RequiredArgsConstructor
+public class ManagerQueryDslRepositoryImpl implements ManagerQueryDslRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public boolean isMemberManager(Long cardId, Long memberId) {
+        if (cardId == null || memberId == null) {
+            throw new ApiException(ErrorStatus.BAD_REQUEST_INVALID_CARD_OR_MEMBER);
+        }
+
+        Integer fetchOne = jpaQueryFactory
+                .selectOne()
+                .from(manager)
+                .where(
+                        managerCardIdEq(cardId)
+                                .and(managerMemberIdEq(memberId))
+                                .and(managerIsNotDeleted())
+                )
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+
+    // 카드 ID와 일치하는 조건 정의
+    private BooleanExpression managerCardIdEq(Long cardId) {
+        return manager.card.id.eq(cardId);
+    }
+
+    // 멤버 ID와 일치하는 조건 정의
+    private BooleanExpression managerMemberIdEq(Long memberId) {
+        return manager.member.id.eq(memberId);
+    }
+
+    // isDeleted가 false인 조건 정의
+    private BooleanExpression managerIsNotDeleted() {
+        return manager.isDeleted.eq(false);
+    }
+
+
+}

--- a/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerRepository.java
@@ -1,7 +1,6 @@
 package com.sparta.springtrello.domain.manager.repository;
 
 import com.sparta.springtrello.domain.manager.entity.Manager;
-import com.sparta.springtrello.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,8 +10,4 @@ import java.util.Optional;
 public interface ManagerRepository extends JpaRepository<Manager,Long> {
     @Query("SELECT m FROM Manager m WHERE m.member.id = :memberId AND m.isDeleted = false")
     Optional<Manager> findByMemberId(@Param("memberId") Long memberId);
-
-    boolean existsByMember_Id(Long memberId);
-
-    boolean existsByMember(Member member);
 }

--- a/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/repository/ManagerRepository.java
@@ -9,12 +9,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface ManagerRepository extends JpaRepository<Manager,Long> {
-    @Query("SELECT m FROM Manager m WHERE m.member.id = :memberId")
+    @Query("SELECT m FROM Manager m WHERE m.member.id = :memberId AND m.isDeleted = false")
     Optional<Manager> findByMemberId(@Param("memberId") Long memberId);
 
     boolean existsByMember_Id(Long memberId);
-
-    Optional<Manager> findByMember(Member member);
 
     boolean existsByMember(Member member);
 }

--- a/src/main/java/com/sparta/springtrello/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/service/ManagerService.java
@@ -86,9 +86,8 @@ public class ManagerService {
                 () -> new ApiException(ErrorStatus.NOT_FOUND_MANAGER)
         );
 
-        foundManager.delete(card);
+        foundManager.delete();
         managerRepository.save(foundManager);
-        cardRespository.save(card);
 
         return new CardManagerChangedResponseDto(cardId,
                 card.getTitle(),

--- a/src/main/java/com/sparta/springtrello/domain/manager/util/ManagerUtil.java
+++ b/src/main/java/com/sparta/springtrello/domain/manager/util/ManagerUtil.java
@@ -4,6 +4,7 @@ import com.sparta.springtrello.common.ErrorStatus;
 import com.sparta.springtrello.common.exception.ApiException;
 import com.sparta.springtrello.domain.card.entity.Card;
 import com.sparta.springtrello.domain.manager.entity.Manager;
+import com.sparta.springtrello.domain.manager.repository.ManagerQueryDslRepository;
 import com.sparta.springtrello.domain.manager.repository.ManagerRepository;
 import com.sparta.springtrello.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -13,40 +14,17 @@ import org.springframework.stereotype.Component;
 @Component
 public class ManagerUtil {
     private final ManagerRepository managerRepository;
+    private final ManagerQueryDslRepository managerQueryDslRepository;
 
     //담당자 등록 기능 메서드
-    public Manager createManager(Card card, Member member) {
-        Manager manager = new Manager();
-        manager.setCard(card);
-        manager.setMember(member);
-        return managerRepository.save(manager);
-    }
-
-    //매니저 Id로 매니저 찾기
-    public Manager findById(Long managerId) {
-        return managerRepository.findById(managerId).orElseThrow(
-                () -> new ApiException(ErrorStatus.NOT_FOUND_MANAGER)
-        );
-    }
-
-    //멤버 객체로 매니저 찾기
-    public Manager findByMember (Member member) {
-        return managerRepository.findByMember(member).orElseThrow(
-                ()-> new ApiException(ErrorStatus.NOT_FOUND_MANAGER)
-        );
-    }
-
-    //해당 멤버가 매니저인지 확인
-    public boolean existsManagerByMember(Member member) {
-        return managerRepository.existsByMember(member);
+    public void createManager(Card card, Member member) {
+        Manager manager = new Manager(card,member);
+        managerRepository.save(manager);
     }
 
     //요청한 유저가 요청한 카드의 매니저인지 검증
     public void validateCardManager(Member member, Card card) {
-        boolean isManager = card.getManagerList().stream()
-                .anyMatch(manager -> manager.getMember().equals(member));
-
-        if (!isManager) {
+        if(!managerQueryDslRepository.isMemberManager(card.getId(),member.getId())) {
             throw new ApiException(ErrorStatus.FORBIDDEN_NOT_MANAGER);
         }
     }

--- a/src/main/java/com/sparta/springtrello/domain/member/argumentresolver/MemberArgumentResolver.java
+++ b/src/main/java/com/sparta/springtrello/domain/member/argumentresolver/MemberArgumentResolver.java
@@ -1,0 +1,68 @@
+package com.sparta.springtrello.domain.member.argumentresolver;
+
+import com.sparta.springtrello.annotation.RequestedMember;
+import com.sparta.springtrello.common.ErrorStatus;
+import com.sparta.springtrello.common.exception.ApiException;
+import com.sparta.springtrello.config.JwtAuthenticationToken;
+import com.sparta.springtrello.domain.auth.dto.AuthUser;
+import com.sparta.springtrello.domain.member.entity.Member;
+import com.sparta.springtrello.domain.member.enums.InvitationStatus;
+import com.sparta.springtrello.domain.member.repository.MemberRepository;
+import com.sparta.springtrello.domain.user.entity.User;
+import com.sparta.springtrello.domain.user.repository.UserRepository;
+import com.sparta.springtrello.domain.workspace.entity.Workspace;
+import com.sparta.springtrello.domain.workspace.repository.WorkspaceRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final MemberRepository memberRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(RequestedMember.class) != null && parameter.getParameterType().equals(Member.class);
+    }
+
+    @Override
+    public Object resolveArgument(@NonNull MethodParameter  parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        // User 객체 가져오기
+        JwtAuthenticationToken authentication = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        AuthUser authUser = (AuthUser) authentication.getPrincipal();
+        User user = userRepository.findById(authUser.getId()).orElseThrow(
+                ()->new ApiException(ErrorStatus.NOT_FOUND_USER)
+        );
+
+        //WorkSpace 가져오기
+        //PathVariable에서 workspaceId 가져오기
+        Map<String, String> pathVariables = (Map<String, String>) webRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, NativeWebRequest.SCOPE_REQUEST);
+        String workspaceIdParam = pathVariables != null ? pathVariables.get("workspaceId") : null;
+
+        if (workspaceIdParam == null) {
+            throw new ApiException(ErrorStatus.BAD_REQUEST_INVALID_WORKSPACE_ID);
+        }
+        Long workspaceId = Long.parseLong(workspaceIdParam);
+
+        Workspace workspace = workspaceRepository.findById(workspaceId).orElseThrow(
+                () -> new ApiException(ErrorStatus.NOT_FOUND_WORKSPACE)
+        );
+
+        // Member 찾기
+        return memberRepository.findAcceptedMember(user, workspace, InvitationStatus.ACCEPT).orElseThrow(
+                () -> new ApiException(ErrorStatus.NOT_FOUND_MEMBER)
+        );
+    }
+}

--- a/src/main/java/com/sparta/springtrello/domain/member/repository/MemberQueryDslRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/member/repository/MemberQueryDslRepository.java
@@ -1,0 +1,5 @@
+package com.sparta.springtrello.domain.member.repository;
+
+public interface MemberQueryDslRepository {
+    public boolean isWorkspaceMember(Long memberId, Long workspaceId);
+}

--- a/src/main/java/com/sparta/springtrello/domain/member/repository/MemberQueryDslRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/member/repository/MemberQueryDslRepository.java
@@ -1,5 +1,5 @@
 package com.sparta.springtrello.domain.member.repository;
 
 public interface MemberQueryDslRepository {
-    public boolean isWorkspaceMember(Long memberId, Long workspaceId);
+    boolean isWorkspaceMember(Long memberId, Long workspaceId);
 }

--- a/src/main/java/com/sparta/springtrello/domain/member/repository/MemberQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/springtrello/domain/member/repository/MemberQueryDslRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.sparta.springtrello.domain.member.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.springtrello.domain.member.enums.InvitationStatus;
+import com.sparta.springtrello.domain.member.enums.MemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.sparta.springtrello.domain.member.entity.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryDslRepositoryImpl implements MemberQueryDslRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public boolean isWorkspaceMember(Long memberId, Long workspaceId) {
+        Integer fetchOne = jpaQueryFactory
+                .selectOne()
+                .from(member)
+                .where(
+                        memberIdEq(memberId)
+                                .and(workspaceIdEq(workspaceId))
+                                .and(isMemberInvited())
+                                .and(isMemberRoleReadOnly())
+                )
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+
+    //MemberId가 같은지
+    private BooleanExpression memberIdEq(Long memberId) {
+        return member.id.eq(memberId);
+    }
+
+    //WorkspaceId가 같은지
+    private BooleanExpression workspaceIdEq(Long workspaceId) {
+        return member.workspace.id.eq(workspaceId);
+    }
+
+    //초대를 수락한 멤버인지
+    private BooleanExpression isMemberInvited() {
+        return member.invitationStatus.eq(InvitationStatus.ACCEPT);
+    }
+
+    //읽기 권한만 있는 건 아닌지
+    private BooleanExpression isMemberRoleReadOnly() {
+        return member.memberRole.ne(MemberRole.READ_ONLY);
+    }
+}

--- a/src/main/java/com/sparta/springtrello/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/member/repository/MemberRepository.java
@@ -1,14 +1,19 @@
 package com.sparta.springtrello.domain.member.repository;
 
 import com.sparta.springtrello.domain.member.entity.Member;
+import com.sparta.springtrello.domain.member.enums.InvitationStatus;
 import com.sparta.springtrello.domain.user.entity.User;
 import com.sparta.springtrello.domain.workspace.entity.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    @Query("SELECT m FROM Member m WHERE m.user = :user AND m.workspace = :workspace AND m.invitationStatus = :status")
+    Optional<Member> findAcceptedMember(@Param("user") User user, @Param("workspace") Workspace workspace, @Param("status") InvitationStatus status);
+
 
     Optional<Member> findByUserAndWorkspace(User user, Workspace workspace);
-
 }

--- a/src/main/java/com/sparta/springtrello/domain/member/service/MemberAuthorizeService.java
+++ b/src/main/java/com/sparta/springtrello/domain/member/service/MemberAuthorizeService.java
@@ -1,8 +1,14 @@
 package com.sparta.springtrello.domain.member.service;
 
+import com.sparta.springtrello.common.ErrorStatus;
+import com.sparta.springtrello.common.exception.ApiException;
 import com.sparta.springtrello.domain.member.entity.Member;
+import com.sparta.springtrello.domain.member.enums.InvitationStatus;
 import com.sparta.springtrello.domain.member.enums.MemberRole;
+import com.sparta.springtrello.domain.member.repository.MemberRepository;
 import com.sparta.springtrello.domain.user.entity.User;
+import com.sparta.springtrello.domain.workspace.entity.Workspace;
+import com.sparta.springtrello.domain.workspace.repository.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,15 +17,15 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class MemberAuthorizeService {
+    private final MemberRepository memberRepository;
+    private final WorkspaceRepository workspaceRepository;
 
     // 특정 workspaceId에 대한 Member 객체를 Optional로 반환하는 공통 메서드
     private Optional<Member> findMemberByWorkspaceId(User user, Long workspaceId) {
-        if (user == null) {
-            return Optional.empty();
-        }
-        return user.getMemberList().stream()
-                .filter(member -> member.getWorkspace().getId().equals(workspaceId))
-                .findFirst();
+        Workspace workspace = workspaceRepository.findById(workspaceId).orElseThrow(
+                ()-> new ApiException(ErrorStatus.NOT_FOUND_WORKSPACE)
+        );
+        return memberRepository.findAcceptedMember(user,workspace, InvitationStatus.ACCEPT);
     }
 
     // workspace에 접근할 수 있는지 검증

--- a/src/main/java/com/sparta/springtrello/domain/member/service/MemberAuthorizeService.java
+++ b/src/main/java/com/sparta/springtrello/domain/member/service/MemberAuthorizeService.java
@@ -20,7 +20,7 @@ public class MemberAuthorizeService {
     private final MemberRepository memberRepository;
     private final WorkspaceRepository workspaceRepository;
 
-    // 특정 workspaceId에 대한 Member 객체를 Optional로 반환하는 공통 메서드
+    // 특정 workspaceId에 대한 Member 객체를 Optional 반환하는 공통 메서드
     private Optional<Member> findMemberByWorkspaceId(User user, Long workspaceId) {
         Workspace workspace = workspaceRepository.findById(workspaceId).orElseThrow(
                 ()-> new ApiException(ErrorStatus.NOT_FOUND_WORKSPACE)
@@ -28,7 +28,7 @@ public class MemberAuthorizeService {
         return memberRepository.findAcceptedMember(user,workspace, InvitationStatus.ACCEPT);
     }
 
-    // workspace에 접근할 수 있는지 검증
+    // workspace 접근할 수 있는지 검증
     public boolean hasAccessToWorkspace(User user, Long workspaceId) {
         // 공통 메서드를 이용하여 Member 존재 여부를 확인
         return findMemberByWorkspaceId(user, workspaceId).isPresent();

--- a/src/main/java/com/sparta/springtrello/domain/notification/entity/SlackUser.java
+++ b/src/main/java/com/sparta/springtrello/domain/notification/entity/SlackUser.java
@@ -1,9 +1,7 @@
 package com.sparta.springtrello.domain.notification.entity;
 
-import jakarta.persistence.Column;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/sparta/springtrello/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/springtrello/domain/notification/service/NotificationService.java
@@ -1,9 +1,6 @@
 package com.sparta.springtrello.domain.notification.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 @Service
 public class NotificationService {

--- a/src/main/java/com/sparta/springtrello/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/springtrello/domain/user/entity/User.java
@@ -62,7 +62,7 @@ public class User extends Timestamped {
         this.kakaoId = kakaoId;
     }
 
-    private User(Long id, String email, UserRole userRole) {
+    public User(Long id, String email, UserRole userRole) {
         this.id = id;
         this.email = email;
         this.userRole = userRole;

--- a/src/main/java/com/sparta/springtrello/domain/workspace/entity/Workspace.java
+++ b/src/main/java/com/sparta/springtrello/domain/workspace/entity/Workspace.java
@@ -31,10 +31,10 @@ public class Workspace {
     private String description;
 
     @Column
-    private Boolean is_deleted = false;
+    private Boolean isDeleted;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "admin_user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @OneToMany(mappedBy = "workspace", cascade = CascadeType.ALL)
@@ -63,7 +63,7 @@ public class Workspace {
     }
 
     public void deleteWorkspace() {
-        is_deleted = true;
+        isDeleted = true;
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,7 @@ spring.datasource.password=${mysql-password}
 #kakao login
 kakao.client.id={kakao-client-id}
 kakao.redirect.uri=http://localhost:8080/auth/kakaoCallback
+
+#multipart ?? ??? ??
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,6 @@ spring.datasource.password=${mysql-password}
 kakao.client.id={kakao-client-id}
 kakao.redirect.uri=http://localhost:8080/auth/kakaoCallback
 
-#multipart ?? ??? ??
+#multipart file size limit
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=5MB


### PR DESCRIPTION
기존에 서비스만 있던 생성,수정,매니저 추가,삭제,첨부파일 추가를 컨트롤러까지 구현하여 작동되게 코드를 추가했습니다. 

매니저 추가, 삭제의 경우 @OneToMany를 사용하지 않게 구현하여 연관관계 편의 메서드에서 발생할 수 있는 오류를 줄이고자 리팩토링했습니다. 

검색기능을 추가했습니다. 

안 쓰는 Import를 제거했습니다.